### PR TITLE
Revert Clean Up Action

### DIFF
--- a/.github/workflows/ofp-decrypt.yml
+++ b/.github/workflows/ofp-decrypt.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
 
-      - name: CleanUp Enviroment
-        uses: rokibhasansagar/slimhub_actions@main
-
       - name: Download OFP Firmware
         run: |
           aria2c -c -s16 -x16 "$OFP_LINK" 2>/dev/null || wget -q --show-progress "$OFP_LINK"


### PR DESCRIPTION
Already a lot of space needed for decryption. 
Also cleanup take nearly 8-12 min and sometime even 20+ mins.  So, we can save time too.